### PR TITLE
fix: Allow already-parsed `body` objects

### DIFF
--- a/.changeset/itchy-icons-flash.md
+++ b/.changeset/itchy-icons-flash.md
@@ -1,0 +1,9 @@
+---
+'@as-integrations/azure-functions': patch
+---
+
+Fix a regression w.r.t body parsing introduced in https://github.com/apollo-server-integrations/apollo-server-integration-azure-functions/pull/28.
+
+Bodies which are already parsed object should just be returned outright rather than treated as invalid.
+
+This issue manifests for users as an invalid POST request from Apollo Server.

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,15 +90,14 @@ function parseBody(
   contentType: string | undefined,
 ): object | null {
   const isValidContentType = contentType?.startsWith('application/json');
-  const isValidPostRequest =
-    method === 'POST' && isValidContentType;
+  const isValidPostRequest = method === 'POST' && isValidContentType;
 
   if (isValidPostRequest) {
     if (typeof body === 'string') {
       return JSON.parse(body);
     }
     if (typeof body === 'object') {
-      return body
+      return body;
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,11 +91,17 @@ function parseBody(
 ): object | null {
   const isValidContentType = contentType?.startsWith('application/json');
   const isValidPostRequest =
-    method === 'POST' && typeof body === 'string' && isValidContentType;
+    method === 'POST' && isValidContentType;
 
   if (isValidPostRequest) {
-    return JSON.parse(body);
+    if (typeof body === 'string') {
+      return JSON.parse(body);
+    }
+    if (typeof body === 'object') {
+      return body
+    }
   }
+
   return null;
 }
 


### PR DESCRIPTION
Fixes a regression introduced in #28.

If the body is already parsed and it's a valid POST request, we can just return it.